### PR TITLE
Sync pnpm-lock.yaml when versioning packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check": "oxlint --fix && oxfmt --write .",
     "check:report": "oxlint && oxfmt --check .",
     "test": "turbo run test",
-    "version-packages": "changeset version && pnpm run format"
+    "version-packages": "changeset version && pnpm install --lockfile-only && pnpm run format"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",


### PR DESCRIPTION
## Why

Last night's release run for 0.13.0 failed at the `pnpm install --frozen-lockfile` gate in the **Version PR / publish gate** job:

```
[ERR_PNPM_OUTDATED_LOCKFILE] ... specifiers in the lockfile don't match specifiers in package.json:
  - coily (lockfile: workspace:^0.12.2, manifest: workspace:^0.13.0)
```

Root cause: `version-packages` runs `changeset version`, which rewrites the playgrounds' `workspace:^x.y.z` ranges, but nothing regenerated `pnpm-lock.yaml` — so every merged Version Packages PR lands on main with a manifest/lockfile mismatch. The currently open Version Packages PR (#12) has the same defect (`workspace:^0.13.1` in the manifest, `^0.13.0` in its lockfile) and would fail the same way if merged as-is.

## Fix

Add `pnpm install --lockfile-only` to `version-packages` so the changesets action commits a matching lockfile into every Version Packages PR. `--lockfile-only` just rewrites the importer specifiers (no node_modules churn, no new package resolution, so the supply-chain gate is unaffected).

Verified locally by running the CI sequence on this branch: `pnpm run version-packages` (consumes the pending 0.13.1 changeset, bumps manifests **and** the lockfile) followed by `pnpm install --frozen-lockfile`, which now passes.

After this merges, the release workflow regenerates #12 with a synced lockfile; merging #12 then publishes 0.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)